### PR TITLE
implemented case insensitive tab completions

### DIFF
--- a/src/main/java/com/w00tmast3r/skquery/elements/expressions/ExprTabCompletions.java
+++ b/src/main/java/com/w00tmast3r/skquery/elements/expressions/ExprTabCompletions.java
@@ -59,7 +59,7 @@ public class ExprTabCompletions extends SimpleExpression<String> {
     public void change(Event e, Object[] delta, Changer.ChangeMode mode) {
         String node = delta[0] == null ? "" : (String) delta[0];
         AttachedTabCompleteEvent event = ((AttachedTabCompleteEvent) e);
-        if (node.startsWith(event.getArgs()[event.getArgs().length - 1])) {
+        if (node.toLowerCase().startsWith(event.getArgs()[event.getArgs().length - 1].toLowerCase())) {
             event.getResult().add(node);
         }
     }


### PR DESCRIPTION
In almost all plugins available (and also built-in Spigot commands) tab completions are always case insensitive. In SkQuery it was impossible to build case insensitive tab completer, which I found as a bug. This pull request makes tab completers work as case insensitive by default.