### PR TITLE
Fix 1 displaying as a prime number

### DIFF
--- a/src/main/java/com/w00tmast3r/skquery/elements/conditions/CondIsPrime.java
+++ b/src/main/java/com/w00tmast3r/skquery/elements/conditions/CondIsPrime.java
@@ -39,6 +39,8 @@ public class CondIsPrime extends Condition {
 	}
 
 	public static boolean isPrime(int number) {
+		if (number == 1)
+			return false;
 		if (number % 2 == 0)
 			return false;
 		for (int i = 3; i * i <= number; i += 2) {


### PR DESCRIPTION
By definition, a prime number admits exactly two divisors : 1 and himself
1 only has one divisor so it's not a prime number